### PR TITLE
Switch to serde for serialization/deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,15 @@ name = "fcm"
 version = "0.2.0"
 dependencies = [
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erased-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -31,9 +34,14 @@ name = "base64"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "bitflags"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
@@ -42,22 +50,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bytes"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "cfg-if"
-version = "0.1.1"
+name = "cc"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "conv"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "core-foundation"
@@ -65,7 +86,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -73,7 +94,7 @@ name = "core-foundation-sys"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -86,28 +107,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fuchsia-zircon"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "futures"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures-cpupool"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "httparse"
@@ -116,21 +166,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.11.0"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -138,26 +189,31 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "iovec"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -175,17 +231,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazycell"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -194,8 +250,25 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "magenta"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "magenta-sys"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,16 +276,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -223,63 +298,69 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "openssl 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "schannel 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "net2"
-version = "0.2.29"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num_cpus"
-version = "1.5.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.9.14"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.14"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -293,22 +374,31 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rand"
+name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.18"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "rustc-serialize"
-version = "0.3.24"
+name = "relay"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -325,13 +415,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "schannel"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -353,22 +443,22 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,14 +467,72 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde_derive"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "slab"
 version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "slab"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "take"
@@ -396,42 +544,42 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-core"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-io"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -440,15 +588,15 @@ name = "tokio-proto"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -457,18 +605,18 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tokio-tls"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -478,6 +626,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
@@ -502,59 +660,80 @@ dependencies = [
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37bb99f5e39ee8b23b6e227f5b8f024207e8616f44aa4b8c76ecd828011667ef"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
+"checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
-"checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
-"checksum cfg-if 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c47d456a36ebf0536a6705c83c1cbbcb9255fbc1d905a6ded104f479268a29"
+"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
+"checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
+"checksum cc 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2c674f0870e3dbd4105184ea035acb1c32c8ae69939c9e228d2b11bbfe29efad"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crypt32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e34988f7e069e0b2f3bfc064295161e489b2d4e04a2e4248fb94360cdf00b4ec"
+"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
+"checksum erased-serde 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a276da68c0fc340922cc612837e34b03cbb314915d5edeea7a1148fcf517546c"
 "checksum foreign-types 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e4056b9bd47f8ac5ba12be771f77a0dae796d1bbaaf5fd0b9c2d38b69b8a29d"
-"checksum futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4b63a4792d4f8f686defe3b39b92127fea6344de5d38202b2ee5a11bbbf29d6a"
-"checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
-"checksum gcc 0.3.51 (registry+https://github.com/rust-lang/crates.io-index)" = "120d07f202dcc3f72859422563522b66fe6463a4c513df062874daad05f85f0a"
+"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
+"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
+"checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
+"checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
-"checksum hyper 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8590f308416a428dca05ca67020283105344e94059fd2f02cc72e9c913c30fb"
-"checksum hyper-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6829541bb9b1716568b3cf353bbcf0566578874b0ffa147922eadc67c7aa3a6"
-"checksum iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29d062ee61fccdf25be172e70f34c9f6efc597e1fb8f6526e8437b2046ab26be"
+"checksum hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b45eac8b696d59491b079bd04fcb0f3488c0f6ed62dcb36bcfea8a543e9cdc3"
+"checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
+"checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
+"checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
-"checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
+"checksum lazycell 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b585b7a6811fb03aa10e74b278a0f00f8dd9b45dc681f148bb29fa5cb61859b"
+"checksum libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "56cce3130fd040c28df6f495c8492e5ec5808fb4c9093c310df02b0c8f030148"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
-"checksum mime 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c5ca99d8a021c1687882fd68dca26e601ceff5c26571c7cb41cf4ed60d57cb2d"
-"checksum mio 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9e965267d4d58496fc4f740e9861118367f13570cadf66316ed2c3f2f14d87c7"
+"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
+"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
+"checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
+"checksum mio 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "dbd91d3bfbceb13897065e97b2ef177a09a438cb33612b2d371bf568819a9313"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum native-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e94a2fc65a44729fe969cc973da87c1052ae3f000b2cb33029f14aeb85550d5"
-"checksum net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)" = "bc01404e7568680f1259aa5729539f221cb1e6d047a0d9053cab4be8a73b5d67"
-"checksum num_cpus 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e416ba127a4bb3ff398cb19546a8d0414f73352efe2857f4060d36f5fe5983a"
-"checksum openssl 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "11ba043cb65fc9af71a431b8a36ffe8686cd4751cdf70a473ec1d01066ac7e41"
-"checksum openssl-sys 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "236c718c2e2c2b58a546d86ffea5194400bb15dbe01ca85325ffd357b03cf66c"
+"checksum native-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04b781c9134a954c84f0594b9ab3f5606abc516030388e8511887ef4c204a1e5"
+"checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
+"checksum num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "99843c856d68d8b4313b03a17e33c4bb42ae8f6610ea81b28abe076ac721b9b0"
+"checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
+"checksum openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf434ff6117485dc16478d77a4f5c84eccc9c3645c4da8323b287ad6a15a638"
+"checksum openssl-sys 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0ad395f1cee51b64a8d07cc8063498dc7554db62d5f3ca87a67f4eed2791d0c8"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum redox_syscall 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "3041aeb6000db123d2c9c751433f526e1f404b23213bd733167ab770c3989b4d"
-"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
+"checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
+"checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
-"checksum schannel 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4e45ac5e9e4698c1c138d2972bedcd90b81fe1efeba805449d2bdd54512de5f9"
+"checksum schannel 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7554288337c1110e34d7a2433518d889374c1de1a45f856b7bcddb03702131fc"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"
-"checksum security-framework 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "42ddf098d78d0b64564b23ee6345d07573e7d10e52ad86875d89ddf5f8378a02"
-"checksum security-framework-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "5bacdada57ea62022500c457c8571c17dfb5e6240b7c8eac5916ffa8c7138a55"
+"checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
+"checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
+"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
+"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
+"checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
+"checksum serde_json 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee28c1d94a7745259b767ca9e5b95d55bafbd3205ca3acb978cad84a6ed6bc62"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
+"checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
-"checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
-"checksum tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6a20ba4738d283cac7495ca36e045c80c2a8df3e05dd0909b17a06646af5a7ed"
-"checksum tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2c3ce9739f7387a0fa65b5421e81feae92e04d603f008898f4257790ce8c2db"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
+"checksum tokio-core 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c843a027f7c1df5f81e7734a0df3f67bf329411781ebf36393ce67beef6071e3"
+"checksum tokio-io 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ab83e7adb5677e42e405fa4ceff75659d93c4d7d7dd22f52fcec59ee9f02af"
 "checksum tokio-proto 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fbb47ae81353c63c487030659494b295f6cb6576242f907f203473b191b0389"
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
-"checksum tokio-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "666266622d9a4d1974a0beda33d505999515b0c60edc0c3fda09784e56609a97"
+"checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
 "checksum unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e01da42520092d0cd2d6ac3ae69eb21a22ad43ff195676b86f8c37f487d6b80"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+"checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,10 @@ documentation = "https://panicbit.github.io/fcm-rust/fcm/"
 keywords = ["fcm", "firebase", "cloud", "messaging", "tokio"]
 
 [dependencies]
-rustc-serialize = "0.3.19"
+serde = "1.0"
+serde_json = "1.0"
+erased-serde = "0.3"
+serde_derive = "1.0"
 futures = "0.1"
 tokio-core = "0.1"
 tokio-service = "0.1"

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -33,7 +33,7 @@ fn main() {
     };
 
     let mut builder = MessageBuilder::new(api_key.as_ref(), device_token.as_ref());
-    builder.data(&data);
+    builder.data(&data).unwrap();
 
     let work = client.send(builder.finalize());
 

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -6,7 +6,6 @@ extern crate tokio_core;
 
 use argparse::{ArgumentParser, Store};
 use fcm::{MessageBuilder, Client};
-use std::collections::HashMap;
 
 #[derive(Serialize)]
 struct CustomData {
@@ -29,12 +28,12 @@ fn main() {
     let handle = core.handle();
     let client = Client::new(&handle).unwrap();
 
-    let mut data = CustomData {
+    let data = CustomData {
         message: "howdy",
     };
 
     let mut builder = MessageBuilder::new(api_key.as_ref(), device_token.as_ref());
-    builder.data(Box::new(data));
+    builder.data(&data);
 
     let work = client.send(builder.finalize());
 

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -2,10 +2,16 @@ extern crate fcm;
 extern crate argparse;
 extern crate futures;
 extern crate tokio_core;
+#[macro_use] extern crate serde_derive;
 
 use argparse::{ArgumentParser, Store};
 use fcm::{MessageBuilder, Client};
 use std::collections::HashMap;
+
+#[derive(Serialize)]
+struct CustomData {
+    message: &'static str,
+}
 
 fn main() {
     let mut device_token = String::new();
@@ -23,11 +29,12 @@ fn main() {
     let handle = core.handle();
     let client = Client::new(&handle).unwrap();
 
-    let mut data = HashMap::new();
-    data.insert("message", "howdy");
+    let mut data = CustomData {
+        message: "howdy",
+    };
 
     let mut builder = MessageBuilder::new(api_key.as_ref(), device_token.as_ref());
-    builder.data(data);
+    builder.data(Box::new(data));
 
     let work = client.send(builder.finalize());
 

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -18,7 +18,7 @@ pub struct MessageResult {
     pub error: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(PartialEq, Debug)]
 pub enum FcmError {
     Unauthorized,
     InvalidMessage(String),

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,6 +1,6 @@
 use hyper::header::RetryAfter;
 
-#[derive(RustcDecodable, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct FcmResponse {
     pub message_id: Option<u64>,
     pub error: Option<String>,
@@ -11,14 +11,14 @@ pub struct FcmResponse {
     pub results: Option<Vec<MessageResult>>,
 }
 
-#[derive(RustcDecodable, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct MessageResult {
     pub message_id: Option<String>,
     pub registration_id: Option<String>,
     pub error: Option<String>,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 pub enum FcmError {
     Unauthorized,
     InvalidMessage(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! map.insert("message", "Howdy!");
 //!
 //! let mut builder = fcm::MessageBuilder::new("<FCM API Key>", "<registration id>");
-//! builder.data(map);
+//! builder.data(Box::new(map));
 //!
 //! let work = client.send(builder.finalize());
 //!
@@ -91,7 +91,10 @@
 //! # }
 //! ```
 
-extern crate rustc_serialize;
+#[macro_use] extern crate serde_derive;
+#[macro_use] extern crate serde_json;
+extern crate serde;
+extern crate erased_serde;
 extern crate hyper;
 extern crate futures;
 extern crate tokio_core;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! map.insert("message", "Howdy!");
 //!
 //! let mut builder = fcm::MessageBuilder::new("<FCM API Key>", "<registration id>");
-//! builder.data(Box::new(map));
+//! builder.data(&map);
 //!
 //! let work = client.send(builder.finalize());
 //!

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -183,7 +183,7 @@ impl MessageBuilder {
     /// builder.data(&map);
     /// let message = builder.finalize();
     /// ```
-    pub fn data<'a>(&mut self, data: &Serialize) -> Result<&mut MessageBuilder, serde_json::Error> {
+    pub fn data(&mut self, data: &Serialize) -> Result<&mut MessageBuilder, serde_json::Error> {
         self.data = Some(serde_json::to_value(data)?);
         Ok(self)
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -180,10 +180,10 @@ impl MessageBuilder {
     /// map.insert("message", "Howdy!");
     ///
     /// let mut builder = MessageBuilder::new("<FCM API Key>", "<registration id>");
-    /// builder.data(Box::new(map));
+    /// builder.data(&map);
     /// let message = builder.finalize();
     /// ```
-    pub fn data<'a>(&mut self, data: Box<Serialize>) -> Result<&mut MessageBuilder, serde_json::Error> {
+    pub fn data<'a>(&mut self, data: &Serialize) -> Result<&mut MessageBuilder, serde_json::Error> {
         self.data = Some(serde_json::to_value(data)?);
         Ok(self)
     }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -37,7 +37,7 @@ fn should_add_custom_data_to_the_payload() {
         bar: false
     };
 
-    builder.data(Box::new(data)).unwrap();
+    builder.data(&data).unwrap();
 
     let msg = builder.finalize();
     let payload = serde_json::to_string(&msg.body).unwrap();

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -1,6 +1,5 @@
 use {MessageBuilder, Priority};
 use notification::NotificationBuilder;
-use std::collections::HashMap;
 use serde_json;
 
 #[test]

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -1,139 +1,199 @@
 use {MessageBuilder, Priority};
 use notification::NotificationBuilder;
 use std::collections::HashMap;
+use serde_json;
 
 #[test]
 fn should_create_new_message() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.to, "token");
+    assert_eq!(msg.body.to, "token");
+}
+
+#[test]
+fn should_leave_nones_out_of_the_json() {
+    let msg = MessageBuilder::new("api_key", "token").finalize();
+    let payload = serde_json::to_string(&msg.body).unwrap();
+
+    let expected_payload = json!({
+        "to": "token"
+    }).to_string();
+
+    assert_eq!(expected_payload, payload);
+}
+
+#[test]
+fn should_add_custom_data_to_the_payload() {
+    let mut builder = MessageBuilder::new("api_key", "token");
+
+    #[derive(Serialize)]
+    struct CustomData {
+        foo: &'static str,
+        bar: bool,
+    };
+
+    let data = CustomData {
+        foo: "bar",
+        bar: false
+    };
+
+    builder.data(Box::new(data)).unwrap();
+
+    let msg = builder.finalize();
+    let payload = serde_json::to_string(&msg.body).unwrap();
+
+    let expected_payload = json!({
+        "data": {
+            "foo": "bar",
+            "bar": false,
+        },
+        "to": "token"
+    }).to_string();
+
+    assert_eq!(expected_payload, payload);
+}
+
+#[test]
+fn should_be_able_to_render_a_full_message_to_json() {
+    let mut builder = MessageBuilder::new("api_key", "token");
+
+    builder.registration_ids(vec!["one", "two"])
+        .collapse_key("foo")
+        .priority(Priority::High)
+        .content_available(false)
+        .delay_while_idle(true)
+        .time_to_live(420)
+        .restricted_package_name("pkg")
+        .notification(NotificationBuilder::new().finalize())
+        .dry_run(false);
+
+    let payload = serde_json::to_string(&builder.finalize().body).unwrap();
+
+    let expected_payload = json!({
+        "to": "token",
+        "registration_ids": ["one", "two"],
+        "collapse_key": "foo",
+        "priority": "high",
+        "content_available": false,
+        "delay_while_idle": true,
+        "time_to_live": 420,
+        "restricted_package_name": "pkg",
+        "dry_run": false,
+        "notification": {},
+    }).to_string();
+
+    assert_eq!(expected_payload, payload);
 }
 
 #[test]
 fn should_set_registration_ids() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.registration_ids, None);
+    assert_eq!(msg.body.registration_ids, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.registration_ids(vec!["id1"]);
     let msg = builder.finalize();
 
-    assert_eq!(msg.registration_ids, Some(vec!["id1".to_string()]));
+    assert_eq!(msg.body.registration_ids, Some(vec!["id1".to_string()]));
 }
 
 #[test]
 fn should_set_collapse_key() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.collapse_key, None);
+    assert_eq!(msg.body.collapse_key, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.collapse_key("key");
     let msg = builder.finalize();
 
-    assert_eq!(msg.collapse_key, Some("key".to_string()));
+    assert_eq!(msg.body.collapse_key, Some("key".to_string()));
 }
 
 #[test]
 fn should_set_priority() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.priority, None);
+    assert_eq!(msg.body.priority, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.priority(Priority::Normal);
     let msg = builder.finalize();
 
-    assert_eq!(msg.priority, Some(Priority::Normal));
+    assert_eq!(msg.body.priority, Some(Priority::Normal));
 }
 
 #[test]
 fn should_set_content_available() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.content_available, None);
+    assert_eq!(msg.body.content_available, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.content_available(true);
     let msg = builder.finalize();
 
-    assert_eq!(msg.content_available, Some(true));
+    assert_eq!(msg.body.content_available, Some(true));
 }
 
 #[test]
 fn should_set_delay_while_idle() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.delay_while_idle, None);
+    assert_eq!(msg.body.delay_while_idle, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.delay_while_idle(true);
     let msg = builder.finalize();
 
-    assert_eq!(msg.delay_while_idle, Some(true));
+    assert_eq!(msg.body.delay_while_idle, Some(true));
 }
 
 #[test]
 fn should_set_time_to_live() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.time_to_live, None);
+    assert_eq!(msg.body.time_to_live, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.time_to_live(10);
     let msg = builder.finalize();
 
-    assert_eq!(msg.time_to_live, Some(10));
+    assert_eq!(msg.body.time_to_live, Some(10));
 }
 
 #[test]
 fn should_set_restricted_package_name() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.restricted_package_name, None);
+    assert_eq!(msg.body.restricted_package_name, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.restricted_package_name("name");
     let msg = builder.finalize();
 
-    assert_eq!(msg.restricted_package_name, Some("name".to_string()));
+    assert_eq!(msg.body.restricted_package_name, Some("name".to_string()));
 }
 
 #[test]
 fn should_set_dry_run() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.dry_run, None);
+    assert_eq!(msg.body.dry_run, None);
 
     let mut builder = MessageBuilder::new("api_key", "token");
     builder.dry_run(true);
     let msg = builder.finalize();
 
-    assert_eq!(msg.dry_run, Some(true));
-}
-
-#[test]
-fn should_set_data() {
-    let msg = MessageBuilder::new("api_key", "token").finalize();
-
-    assert_eq!(msg.data, None);
-
-    let mut data = HashMap::new();
-    data.insert("my", "data");
-
-    let mut builder = MessageBuilder::new("api_key", "token");
-    builder.data(data);
-    let msg = builder.finalize();
-
-    assert_eq!(msg.data.unwrap().get("my"), Some(&"data".to_string()));
+    assert_eq!(msg.body.dry_run, Some(true));
 }
 
 #[test]
 fn should_set_notifications() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.notification, None);
+    assert_eq!(msg.body.notification, None);
 
     let nm = NotificationBuilder::new().finalize();
 
@@ -141,5 +201,5 @@ fn should_set_notifications() {
     builder.notification(nm);
     let msg = builder.finalize();
 
-    assert!(msg.notification != None);
+    assert!(msg.body.notification != None);
 }

--- a/src/notification/mod.rs
+++ b/src/notification/mod.rs
@@ -1,84 +1,46 @@
 #[cfg(test)]
 mod tests;
 
-use std::collections::BTreeMap;
-use rustc_serialize::json::{ToJson, Json};
-
 /// This struct represents a FCM notification. Use the 
 /// corresponding `NotificationBuilder` to get an instance. You can then use 
 /// this notification instance when sending a FCM message.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Debug, PartialEq)]
 pub struct Notification {
-    title: Option<String>,
-    body: Option<String>,
-    icon: Option<String>,
-    sound: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     badge: Option<String>,
-    tag: Option<String>,
-    color: Option<String>,
-    click_action: Option<String>,
-    body_loc_key: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     body_loc_args: Option<Vec<String>>,
-    title_loc_key: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    body_loc_key: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    click_action: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    color: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    icon: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sound: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     title_loc_args: Option<Vec<String>>,
-}
 
-impl ToJson for Notification {
-    fn to_json(&self) -> Json {
-        let mut root = BTreeMap::new();
-
-        if self.title.is_some() {
-            root.insert("title".to_string(), self.title.clone().unwrap().to_json());
-        }
-
-        if self.icon.is_some() {
-            root.insert("icon".to_string(), self.icon.clone().unwrap().to_json());
-        }
-
-        if self.body.is_some() {
-            root.insert("body".to_string(), self.body.clone().unwrap().to_json());
-        }
-
-        if self.sound.is_some() {
-            root.insert("sound".to_string(), self.sound.clone().unwrap().to_json());
-        }
-
-        if self.badge.is_some() {
-            root.insert("badge".to_string(), self.badge.clone().unwrap().to_json());
-        }
-
-        if self.tag.is_some() {
-            root.insert("tag".to_string(), self.tag.clone().unwrap().to_json());
-        }
-
-        if self.color.is_some() {
-            root.insert("color".to_string(), self.color.clone().unwrap().to_json());
-        }
-
-        if self.click_action.is_some() {
-            root.insert("click_action".to_string(), self.click_action.clone().unwrap().to_json());
-        }
-
-        if self.body_loc_key.is_some() {
-            root.insert("body_loc_key".to_string(), self.body_loc_key.clone().unwrap().to_json());
-        }
-
-        if self.body_loc_args.is_some() {
-            let body_loc_args_str = self.body_loc_args.clone().unwrap().to_json().to_string();
-            root.insert("body_loc_args".to_string(), Json::String(body_loc_args_str));
-        }
-
-        if self.title_loc_key.is_some() {
-            root.insert("title_loc_key".to_string(), self.title_loc_key.clone().unwrap().to_json());
-        }
-
-        if self.title_loc_args.is_some() {
-            let title_loc_args_str = self.title_loc_args.clone().unwrap().to_json().to_string();
-            root.insert("title_loc_args".to_string(), Json::String(title_loc_args_str));
-        }
-
-        Json::Object(root)
-    }
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title_loc_key: Option<String>,
 }
 
 /// A builder to get a `Notification` instance.
@@ -128,44 +90,58 @@ impl NotificationBuilder {
     }
 
     // Set the title of the notification
-    pub fn title<S: Into<String>>(&mut self, title: S) -> &mut NotificationBuilder {
+    pub fn title<S>(&mut self, title: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.title = Some(title.into());
         self
     }
 
     /// Set the body of the notification
-    pub fn body<S: Into<String>>(&mut self, body: S) -> &mut NotificationBuilder {
+    pub fn body<S>(&mut self, body: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.body = Some(body.into());
         self
     }
 
     /// Set the notification icon.
-    pub fn icon<S: Into<String>>(&mut self, icon: S) -> &mut NotificationBuilder {
+    pub fn icon<S>(&mut self, icon: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.icon = Some(icon.into());
         self
     }
 
     /// Set the sound to be played
-    pub fn sound<S: Into<String>>(&mut self, sound: S) -> &mut NotificationBuilder {
+    pub fn sound<S>(&mut self, sound: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.sound = Some(sound.into());
         self
     }
 
     /// Set the badge for iOS notifications
-    pub fn badge<S: Into<String>>(&mut self, badge: S) -> &mut NotificationBuilder {
+    pub fn badge<S>(&mut self, badge: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.badge = Some(badge.into());
         self
     }
 
     /// Tagging a notification allows you to replace existing notifications
     /// with the same tag with this new notification
-    pub fn tag<S: Into<String>>(&mut self, tag: S) -> &mut NotificationBuilder {
+    pub fn tag<S>(&mut self, tag: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.tag = Some(tag.into());
         self
     }
 
     /// The color of the icon, in #rrggbb format
-    pub fn color<S: Into<String>>(&mut self, color: S) -> &mut NotificationBuilder {
+    pub fn color<S>(&mut self, color: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.color = Some(color.into());
         self
     }
@@ -173,31 +149,41 @@ impl NotificationBuilder {
     /// What happens when the user clicks on the notification. Refer to 
     /// https://developers.google.com/cloud-messaging/http-server-ref#table2 for
     /// details.
-    pub fn click_action<S: Into<String>>(&mut self, click_action: S) -> &mut NotificationBuilder {
+    pub fn click_action<S>(&mut self, click_action: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.click_action = Some(click_action.into());
         self
     }
 
     /// Set the body key string for localization
-    pub fn body_loc_key<S: Into<String>>(&mut self, body_loc_key: S) -> &mut NotificationBuilder {
+    pub fn body_loc_key<S>(&mut self, body_loc_key: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.body_loc_key = Some(body_loc_key.into());
         self
     }
 
     /// String value to replace format specifiers in the body string.
-    pub fn body_loc_args<S: Into<String>>(&mut self, body_loc_args: Vec<S>) -> &mut NotificationBuilder {
+    pub fn body_loc_args<S>(&mut self, body_loc_args: Vec<S>) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.body_loc_args = Some(body_loc_args.into_iter().map(|s| s.into()).collect());
         self
     }
 
     /// Set the title key string for localization
-    pub fn title_loc_key<S: Into<String>>(&mut self, title_loc_key: S) -> &mut NotificationBuilder {
+    pub fn title_loc_key<S>(&mut self, title_loc_key: S) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.title_loc_key = Some(title_loc_key.into());
         self
     }
 
     /// String value to replace format specifiers in the title string.
-    pub fn title_loc_args<S: Into<String>>(&mut self, title_loc_args: Vec<S>) -> &mut NotificationBuilder {
+    pub fn title_loc_args<S>(&mut self, title_loc_args: Vec<S>) -> &mut NotificationBuilder
+        where S: Into<String>
+    {
         self.title_loc_args = Some(title_loc_args.into_iter().map(|s| s.into()).collect());
         self
     }

--- a/src/notification/tests.rs
+++ b/src/notification/tests.rs
@@ -1,7 +1,42 @@
-extern crate rustc_serialize;
-
-use rustc_serialize::json::{ToJson};
+use serde_json;
 use {NotificationBuilder};
+
+#[test]
+fn should_be_able_to_render_a_full_notification_to_json() {
+    let mut builder = NotificationBuilder::new();
+
+    builder.title("foo")
+        .body("bar")
+        .icon("gif")
+        .sound("pling")
+        .badge("12")
+        .tag("spook")
+        .color("#666666")
+        .click_action("spam")
+        .body_loc_key("PLAY")
+        .body_loc_args(vec!["foo", "bar"])
+        .title_loc_key("PAUSE")
+        .title_loc_args(vec!["omg", "lol"]);
+
+    let payload = serde_json::to_string(&builder.finalize()).unwrap();
+
+    let expected_payload = json!({
+        "badge": "12",
+        "body": "bar",
+        "body_loc_args": ["foo", "bar"],
+        "body_loc_key": "PLAY",
+        "click_action": "spam",
+        "color": "#666666",
+        "icon": "gif",
+        "sound": "pling",
+        "tag": "spook",
+        "title": "foo",
+        "title_loc_args": ["omg", "lol"],
+        "title_loc_key": "PAUSE"
+    }).to_string();
+
+    assert_eq!(expected_payload, payload);
+}
 
 #[test]
 fn should_set_notification_title() {
@@ -15,6 +50,7 @@ fn should_set_notification_title() {
 
     assert_eq!(nm.title, Some("title".to_string()));
 }
+
 #[test]
 fn should_set_notification_body() {
     let nm = NotificationBuilder::new().finalize();
@@ -126,7 +162,6 @@ fn should_set_notification_body_loc_args() {
     let nm = builder.finalize();
 
     assert_eq!(nm.body_loc_args, Some(vec!["args".to_string()]));
-    assert_eq!(nm.to_json().search("body_loc_args").unwrap().as_string(), Some("[\"args\"]"));
 }
 
 #[test]
@@ -153,5 +188,4 @@ fn should_set_notification_title_loc_args() {
     let nm = builder.finalize();
 
     assert_eq!(nm.title_loc_args, Some(vec!["args".to_string()]));
-    assert_eq!(nm.to_json().search("title_loc_args").unwrap().as_string(), Some("[\"args\"]"));
 }


### PR DESCRIPTION
`rustc_serialize` is deprecated, `serde` taking it's place as the serialization solution. Using serde's nice macros we don't need our own JSON serialization code.

I could almost completely make the shift without breaking the API, but the custom data setup I had to change to accept anything that is deriving the `Serialize` functionality, so what that means is:

* The data parameter must be wrapped in a `Box` just so we can use almost anything that can be serialized as a parameter
* Which means, the custom data can now be made type-safe, which is a huge win at least in our projects.

I did a pull request to open up discussion first. This requires a major version change because of that broken API. I can bump the version and publish a new version if this looks OK to you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/fcm-rust/3)
<!-- Reviewable:end -->
