### PR TITLE
Add Display and Error impls

### DIFF
--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -146,11 +146,7 @@ pub enum FcmError {
     ServerError(Option<RetryAfter>),
 }
 
-impl Error for FcmError {
-    
-
-
-}
+impl Error for FcmError {}
 
 impl fmt::Display for FcmError {
    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+use std::fmt;
 pub use chrono::{DateTime, FixedOffset, Duration};
 
 /// A description of what went wrong with the push notification.
@@ -142,6 +144,23 @@ pub enum FcmError {
     ///
     /// Senders that cause problems risk being blacklisted.
     ServerError(Option<RetryAfter>),
+}
+
+impl Error for FcmError {
+    
+
+
+}
+
+impl fmt::Display for FcmError {
+   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+       match self {
+           FcmError::Unauthorized => 
+               write!(f, "authorization header missing or with invalid syntax in HTTP request"),
+           FcmError::InvalidMessage(ref s) => write!(f, "invalid message {}", s),
+           FcmError::ServerError(_) => write!(f, "the server couldn't process the request")
+       }
+   }
 }
 
 #[derive(PartialEq, Debug)]


### PR DESCRIPTION
Added Display and Error implementations for interoperability using this as a guide:
https://github.com/rust-lang-nursery/api-guidelines/blob/master/src/interoperability.md#error-types-are-meaningful-and-well-behaved-c-good-err

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/fcm-rust/15)
<!-- Reviewable:end -->
