### PR TITLE
Fix multi push

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -96,8 +96,7 @@ pub struct MessageBuilder<'a> {
 }
 
 impl<'a> MessageBuilder<'a> {
-    /// Get a new instance of Message. You need to supply either
-    /// a registration id, or a topic (/topics/...).
+    /// Get a new instance of Message. You need to supply to.
     pub fn new(api_key: &'a str, to: &'a str) -> Self {
         MessageBuilder {
             api_key: api_key,
@@ -115,8 +114,7 @@ impl<'a> MessageBuilder<'a> {
         }
     }
 
-    /// Get a new instance of Message. You need to supply either
-    /// a registration id, or a topic (/topics/...).
+    /// Get a new instance of Message. You need to supply registration ids.
     pub fn new_multi<S>(api_key: &'a str, ids: &'a [S]) -> Self
         where
             S: Into<Cow<'a, str>> + AsRef<str>,

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -7,7 +7,7 @@ use crate::{MessageBuilder, Priority};
 fn should_create_new_message() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 
-    assert_eq!(msg.body.to, "token");
+    assert_eq!(msg.body.to, Some("token"));
 }
 
 #[test]


### PR DESCRIPTION
Multi pushes didn't work. The _to_ field in _MessageBody_ needed to be removed if multiple registration ids where provided.
I made the needed changes and added a new function to directly create a multi-push message.

Also, in order to make the tests run correctly, I needed to change the check of the _to_ field in the test class, as the field is now optional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/fcm-rust/17)
<!-- Reviewable:end -->
