### PR TITLE
refactor: changed the http client to reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,18 @@ documentation = "https://docs.rs/fcm/"
 keywords = ["fcm", "firebase", "notification"]
 edition = "2018"
 
+[features]
+default = ["native-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls = ["reqwest/rustls-tls"]
+vendored-tls = ["reqwest/native-tls-vendored"]
+
 [dependencies]
 serde = "1"
 serde_json = "1"
 erased-serde = "0.3"
 serde_derive = "1"
-futures = "0.3"
-hyper = { version = "0.14", features = ["http1", "stream"] }
-hyper-tls = "0.5"
-http = "0.2"
+reqwest = {version = "0.11.0", features = ["json"], default-features=false}
 chrono = "0.4"
 log = "0.4"
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -2,50 +2,44 @@ pub mod response;
 
 pub use crate::client::response::*;
 
-use futures::stream::StreamExt;
-use http::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, RETRY_AFTER};
-use hyper::{
-    client::{Client as HttpClient, HttpConnector},
-    Body, Request, StatusCode,
-};
-use hyper_tls::{self, HttpsConnector};
 use crate::message::Message;
+use reqwest::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, RETRY_AFTER};
+use reqwest::{Body, StatusCode};
 use serde_json;
 
 /// An async client for sending the notification payload.
 pub struct Client {
-    http_client: HttpClient<HttpsConnector<HttpConnector>>,
+    http_client: reqwest::Client,
 }
 
 impl Client {
     /// Get a new instance of Client.
     pub fn new() -> Client {
-        let mut http_client = HttpClient::builder();
-        http_client.pool_max_idle_per_host(std::usize::MAX);
+        let http_client = reqwest::ClientBuilder::new()
+            .pool_max_idle_per_host(std::usize::MAX)
+            .build()
+            .unwrap();
 
-        Client {
-            http_client: http_client.build(HttpsConnector::new()),
-        }
+        Client { http_client }
     }
 
     /// Try sending a `Message` to FCM.
     pub async fn send(&self, message: Message<'_>) -> Result<FcmResponse, FcmError> {
         let payload = serde_json::to_vec(&message.body).unwrap();
 
-        let builder = Request::builder()
-            .method("POST")
+        let request = self
+            .http_client
+            .post("https://fcm.googleapis.com/fcm/send")
             .header(CONTENT_TYPE, "application/json")
             .header(
                 CONTENT_LENGTH,
                 format!("{}", payload.len() as u64).as_bytes(),
             )
             .header(AUTHORIZATION, format!("key={}", message.api_key).as_bytes())
-            .uri("https://fcm.googleapis.com/fcm/send");
+            .body(Body::from(payload))
+            .build()?;
+        let response = self.http_client.execute(request).await?;
 
-        let request = builder.body(Body::from(payload)).unwrap();
-        let requesting = self.http_client.request(request);
-
-        let response = requesting.await?;
         let response_status = response.status();
 
         let retry_after = response
@@ -54,23 +48,9 @@ impl Client {
             .and_then(|ra| ra.to_str().ok())
             .and_then(|ra| RetryAfter::from_str(ra));
 
-        let content_length: usize = response
-            .headers()
-            .get(CONTENT_LENGTH)
-            .and_then(|s| s.to_str().ok())
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
-
-        let mut body: Vec<u8> = Vec::with_capacity(content_length);
-        let mut chunks = response.into_body();
-
-        while let Some(chunk) = chunks.next().await {
-            body.extend_from_slice(&chunk?);
-        }
-
         match response_status {
             StatusCode::OK => {
-                let fcm_response: FcmResponse = serde_json::from_slice(&body).unwrap();
+                let fcm_response: FcmResponse = response.json().await.unwrap();
 
                 match fcm_response.error {
                     Some(ErrorReason::Unavailable) => {
@@ -86,9 +66,7 @@ impl Client {
             StatusCode::BAD_REQUEST => Err(response::FcmError::InvalidMessage(
                 "Bad Request".to_string(),
             )),
-            status if status.is_server_error() => {
-                Err(response::FcmError::ServerError(retry_after))
-            }
+            status if status.is_server_error() => Err(response::FcmError::ServerError(retry_after)),
             _ => Err(response::FcmError::InvalidMessage(
                 "Unknown Error".to_string(),
             )),

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -161,8 +161,8 @@ impl fmt::Display for FcmError {
     }
 }
 
-impl From<hyper::Error> for FcmError {
-    fn from(_: hyper::Error) -> Self {
+impl From<reqwest::Error> for FcmError {
+    fn from(_: reqwest::Error) -> Self {
         Self::ServerError(None)
     }
 }


### PR DESCRIPTION
For our project of rust matrix push gateway https://gitlab.com/famedly/services/hedwig, we decided to go with rustls for an easier cross compilation to Arm.

Switching the used http client to reqwest is recommended by hyper devs and makes it easier to choose the tls implementation :)

Functionality was confirmed on Raspberry Pi based gateway with matrix client Fluffychat.

It should also resolve #21 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/fcm-rust/22)
<!-- Reviewable:end -->
