### PR TITLE
Switch to Actix (awc)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,20 +14,20 @@ keywords = ["fcm", "firebase", "notification"]
 edition = "2018"
 
 [features]
-default = ["native-tls"]
-native-tls = ["reqwest/native-tls"]
-rustls = ["reqwest/rustls-tls"]
-vendored-tls = ["reqwest/native-tls-vendored"]
+default = ["rustls"]
+rustls = ["awc/rustls"]
+openssl = ["awc/openssl"]
+
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 erased-serde = "0.3"
-reqwest = {version = "0.11.0", features = ["json"], default-features=false}
+awc = "3.0.0-beta"
 chrono = "0.4"
 log = "0.4"
 
 [dev-dependencies]
 argparse = "0.2.1"
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+actix-rt = "2.2.0"
 pretty_env_logger = "0.3"

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -7,7 +7,7 @@ struct CustomData {
     message: &'static str,
 }
 
-#[tokio::main]
+#[actix_rt::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     pretty_env_logger::init();
 

--- a/src/client/response.rs
+++ b/src/client/response.rs
@@ -1,3 +1,4 @@
+use awc::error::SendRequestError;
 pub use chrono::{DateTime, Duration, FixedOffset};
 use serde::Deserialize;
 use std::{error::Error, fmt, str::FromStr};
@@ -158,8 +159,8 @@ impl fmt::Display for FcmError {
     }
 }
 
-impl From<reqwest::Error> for FcmError {
-    fn from(_: reqwest::Error) -> Self {
+impl From<SendRequestError> for FcmError {
+    fn from(_: SendRequestError) -> Self {
         Self::ServerError(None)
     }
 }


### PR DESCRIPTION
Switch to using a recent version of awc on an actix_rt

Realistically, I plan on using this with an actix deployment, there is no reason to use hyper or reqwest.

One of the focuses of #24 was compile time, a `cargo clean && cargo build --release --example simple_sender` took
```
   Compiling awc v3.0.0-beta.18
   Compiling fcm v0.9.1 (/Users/jwtrueb/Desktop/workspace/fcm-rust)
    Finished release [optimized] target(s) in 38.60s
```
and a `cargo clean && cargo build --release --example simple_sender --features openssl`
```
   Compiling awc v3.0.0-beta.18
   Compiling fcm v0.9.1 (/Users/jwtrueb/Desktop/workspace/fcm-rust)
    Finished release [optimized] target(s) in 41.38s
```

Here are the some of the features available on awc
```
[package.metadata.docs.rs]
# features that docs.rs will build with
features = ["openssl", "rustls", "compress-brotli", "compress-gzip", "compress-zstd", "cookies"]

[features]
default = ["compress-brotli", "compress-gzip", "compress-zstd", "cookies"]

# openssl
openssl = ["tls-openssl", "actix-tls/openssl"]

# rustls
rustls = ["tls-rustls", "actix-tls/rustls"]
```

I set the default feature `rustls`, since we need SSL