### PR TITLE
Added field 'mutable_content' for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fcm"
-version = "0.9.1"
+version = "0.9.2"
 authors = [
   "Suvish Varghese Thoovamalayil <vishy1618@gmail.com>",
   "panicbit <panicbit.dev@gmail.com>",

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -49,6 +49,9 @@ pub struct MessageBody<'a> {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     to: Option<&'a str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mutable_content: Option<bool>,
 }
 
 /// Represents a FCM message. Construct the FCM message
@@ -93,6 +96,7 @@ pub struct MessageBuilder<'a> {
     restricted_package_name: Option<&'a str>,
     time_to_live: Option<i32>,
     to: Option<&'a str>,
+    mutable_content: Option<bool>,
 }
 
 impl<'a> MessageBuilder<'a> {
@@ -111,6 +115,7 @@ impl<'a> MessageBuilder<'a> {
             dry_run: None,
             data: None,
             notification: None,
+            mutable_content: None,
         }
     }
 
@@ -134,6 +139,7 @@ impl<'a> MessageBuilder<'a> {
             dry_run: None,
             data: None,
             notification: None,
+            mutable_content: None,
         }
     }
 
@@ -239,6 +245,12 @@ impl<'a> MessageBuilder<'a> {
         self
     }
 
+    /// To set the `mutable_content` field on iOS
+    pub fn mutable_content(&mut self, mutable_content: bool) -> &mut Self {
+        self.mutable_content = Some(mutable_content);
+        self
+    }
+
     /// Complete the build and get a `Message` instance
     pub fn finalize(self) -> Message<'a> {
         Message {
@@ -255,6 +267,7 @@ impl<'a> MessageBuilder<'a> {
                 dry_run: self.dry_run,
                 data: self.data.clone(),
                 notification: self.notification,
+                mutable_content: self.mutable_content,
             },
         }
     }

--- a/src/message/tests.rs
+++ b/src/message/tests.rs
@@ -140,6 +140,19 @@ fn should_set_content_available() {
 }
 
 #[test]
+fn should_set_mutable_content() {
+    let msg = MessageBuilder::new("api_key", "token").finalize();
+
+    assert_eq!(msg.body.mutable_content, None);
+
+    let mut builder = MessageBuilder::new("api_key", "token");
+    builder.mutable_content(true);
+    let msg = builder.finalize();
+
+    assert_eq!(msg.body.mutable_content, Some(true));
+}
+
+#[test]
 fn should_set_delay_while_idle() {
     let msg = MessageBuilder::new("api_key", "token").finalize();
 


### PR DESCRIPTION
See https://firebase.google.com/docs/cloud-messaging/http-server-ref

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/fcm-rust/30)
<!-- Reviewable:end -->
